### PR TITLE
Server dockerization

### DIFF
--- a/.github/workflows/gce_deploy.yml
+++ b/.github/workflows/gce_deploy.yml
@@ -1,0 +1,74 @@
+# Copyright 2020 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# referenced from below address w/modifications:
+# https://github.com/google-github-actions/setup-gcloud/blob/d4f608db2526f5746be097a32cf33cf652fd9498/example-workflows/gce/.github/workflows/gce.yaml
+
+name: Build and Deploy to Google Compute Engine
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "server"
+env:
+  PROJECT_ID: ${{ secrets.GCE_PROJECT }}
+  GCE_INSTANCE: word-lapse-api  # TODO: update to instance name
+  GCE_INSTANCE_ZONE: us-central1-a   # TODO: update to instance zone
+
+jobs:
+  setup-build-publish-deploy:
+    name: Setup, Build, Publish, and Deploy
+    runs-on: ubuntu-latest
+
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Alternative option - authentication via credentials json
+    - id: 'auth'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+    # Setup gcloud CLI
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v0
+
+    # Configure Docker to use the gcloud command-line tool as a credential
+    # helper for authentication
+    - run: |-
+        gcloud --quiet auth configure-docker
+
+    # Build the Docker image
+    - name: Build
+      run: |-
+        docker build --platform linux/amd64 --tag "gcr.io/$PROJECT_ID/$GCE_INSTANCE-image:$GITHUB_SHA" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Publish
+      run: |-
+        docker push "gcr.io/$PROJECT_ID/$GCE_INSTANCE-image:$GITHUB_SHA"
+
+    - name: Deploy
+      run: |-
+        gcloud compute instances update-container "$GCE_INSTANCE" \
+          --zone "$GCE_INSTANCE_ZONE" \
+          --container-image "gcr.io/$PROJECT_ID/$GCE_INSTANCE-image:$GITHUB_SHA"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn == 0.23.2
 spacy == 2.2.3
 tensorflow >= 2.0.0
 umap-learn == 0.5.1
+uvicorn == 0.16.0

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,11 @@
+/.venv
+/.github
+/.vscode
+/server/data
+
+# # exclude git in general...
+/.git
+# # ...but allow specific metadata paths
+# !/.git/HEAD
+# !/.git/config
+# !/.git/refs

--- a/server/.gcloudignore
+++ b/server/.gcloudignore
@@ -1,0 +1,4 @@
+/.venv
+/.vscode
+/.github
+/.git

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.9
+
+# RUN apk add build-base
+
+WORKDIR /app
+
+# install git-lfs, so we can pull lfs files
+# also install letsencrypt, so we can update our SSL cert before running
+RUN apt update && apt install git-lfs letsencrypt -y
+
+# COPY ./requirements.txt /tmp/requirements.txt
+COPY ./server_requirements.txt /tmp/server_requirements.txt
+RUN pip install -r /tmp/server_requirements.txt
+
+# track the short and full git commit from which this image was built
+ARG SHORT_SHA=unspecified
+LABEL git_commit=$SHORT_SHA
+ARG COMMIT_SHA=unspecified
+LABEL git_commit_full=$COMMIT_SHA
+
+COPY . /app
+
+# ./data will contain several gb of models, so it's more efficient
+# to have it as a persistent volume rather than baking it into the docker
+# image, or populating it every time the container starts
+# ---
+# the entrypoint script will check if it needs to be populated when the
+# container starts up
+VOLUME [ "/app/data" ]
+
+# also assign certs provisioned within the container to a volume
+VOLUME [ "/etc/letsencrypt" ]
+
+EXPOSE 80
+EXPOSE 443
+
+CMD ["/app/entrypoint.sh"]

--- a/server/build_deploy.sh
+++ b/server/build_deploy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+SHORT_SHA=$(git log -1 --format=%h)
+COMMIT_SHA=$(git log -1 --format=%H)
+
+BUILDS_SKIPPED=${SKIP_BUILD:-0}
+DEPLOY_SKIPPED=${SKIP_DEPLOY:-0}
+
+if [ ${BUILD_LOCAL:-0} -eq 1 ]; then
+    echo "Executing local build..."
+    docker build \
+        --platform linux/amd64 \
+        -t gcr.io/word-lapse/word-lapse-api-image:${COMMIT_SHA} \
+        --build-arg SHORT_SHA=${SHORT_SHA} \
+        --build-arg COMMIT_SHA=${COMMIT_SHA} \
+        .
+    docker push gcr.io/word-lapse/word-lapse-api-image:${COMMIT_SHA}
+else
+    # farm it off to gcloud build and deploy to the vm
+    echo "Executing remote build on gcloud..."
+
+    (
+        [[ "$BUILDS_SKIPPED" == "1" ]] && echo "skipping remote build..." || \
+        gcloud builds submit --project=word-lapse --timeout=2h30m \
+            . --tag gcr.io/word-lapse/word-lapse-api-image:${COMMIT_SHA}
+    ) && (
+        [[ "$DEPLOY_SKIPPED" == "1" ]] && echo "skipping deploy..." || \
+        gcloud compute instances update-container --project=word-lapse word-lapse-api \
+            --container-image gcr.io/word-lapse/word-lapse-api-image:${COMMIT_SHA} \
+            --container-mount-host-path=mount-path=/app/data,host-path=/mnt/stateful_partition/word-lapse-data,mode=rw \
+            --container-mount-host-path=mount-path=/etc/letsencrypt,host-path=/var/letsencrypt,mode=rw
+    )
+fi

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+function dir_is_empty {
+    [ -n "$(find "$1" -maxdepth 0 -type d -empty 2>/dev/null)" ]
+}
+
+# if /app/data is populated, attempt a git lfs pull
+# if it's not, clone word-lapse-models into it and then pull
+if [ "${UPDATE_DATA:-1}" = "1" ]; then
+    DATA_DIR=/app/data/
+
+    # squelch hostname checks about github.com
+    mkdir -p ~/.ssh && ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts
+
+    # ensure DATA_DIR exists
+    mkdir -p "${DATA_DIR}"
+
+    if dir_is_empty "${DATA_DIR}"; then
+        # the folder is empty
+        # clone submodule into ./data and do an lfs pull
+        echo "* ${DATA_DIR} is empty, cloning data into it"
+        git clone 'https://github.com/greenelab/word-lapse-models.git' "${DATA_DIR}"
+        cd /app/data && git lfs pull
+    else
+        # just attempt to pull new data into the existing folder
+        echo "* ${DATA_DIR} is *not* empty, refreshing contents"
+        cd /app/data && git lfs pull
+    fi
+fi
+
+if [ "${USE_HTTPS:-1}" = "1" ]; then
+    # check if our certificate needs to be created (e.g., if it's missing)
+    # or if we just need to renew
+    if dir_is_empty /etc/letsencrypt/; then
+        certbot certonly \
+            --non-interactive --standalone --agree-tos \
+            -m "${ADMIN_EMAIL:-faisal.alquaddoomi@cuanschutz.edu}" \
+            -d "${DNS_NAME:-api-wl.greenelab.com}"
+    else
+        # most of the time this is a no-op, since it won't renew if it's not near expiring
+        certbot renew
+    fi
+
+    # finally, run the server
+    cd /app
+    /usr/local/bin/uvicorn main:app --host 0.0.0.0 --port 443 \
+        --ssl-keyfile=/etc/letsencrypt/live/api-wl.greenelab.com/privkey.pem \
+        --ssl-certfile=/etc/letsencrypt/live/api-wl.greenelab.com/fullchain.pem
+else
+    # finally, run the server
+    cd /app
+    /usr/local/bin/uvicorn main:app --host 0.0.0.0 --port 80
+fi

--- a/server/server_requirements.txt
+++ b/server/server_requirements.txt
@@ -1,0 +1,2 @@
+fastapi == 0.70.1
+uvicorn == 0.17.0


### PR DESCRIPTION
This PR adds the following to the `./server` directory:
- a `Dockerfile`, which maps `./server` to the container's working directory, `/app`
- `entrypoint.sh`, an entrypoint script that runs when the container starts
- `build_deploy.sh`, a convenience build script
- `server_requirements.txt`, the base requirements to run the server as it is now
- various metadata for the Docker and GCloud build processes (`.dockerignore`, `.gcloudignore`)

The PR also adds a GH action to build and deploy the Docker image to the Word Lapse API VM when a push to `main` affects the `./server` folder. The action relies on the secrets `GCE_PROJECT` and `GCP_CREDENTIALS`, both of which have been registered as secrets in the GitHub project settings.

The entrypoint script does the following:
1. If `/app/data` is empty, clones https://github.com/greenelab/word-lapse-models into that folder. If it's not empty it performs an LFS pull in that folder. (This behavior can be disabled by setting the env var `UPDATE_DATA` to 0.)
2. If `/etc/letsencrypt/` is empty, uses Let's Encrypt to create a certificate for `api-wl.greenelab.com`. If it's not empty, it attempts to renew the certificate, which is a no-op if the certificate doesn't need renewal. (This behavior can be disabled by setting the env var `USE_HTTPS` to 0.)
3. Starts uvicorn, a performant WSGI-hosting webserver, to serve the API. If `USE_HTTPS` is unspecified, runs the server on port 443 with SSL using the certificate; if `USE_HTTPS` is 0, runs the server on port 80 without SSL.

The build script does the following:
1. If the env var `BUILD_LOCAL` is 1, builds the image locally and pushes it to `gcr.io/word-lapse/word-lapse-api-image:${COMMIT_SHA}`, where `COMMIT_SHA` is the latest commit hash in the server folder.
2. If `BUILD_LOCAL` is unspecified, performs a remote build using Google's Cloud Build service, then deploys the image to the Word Lapse API server, restarting it if it's running or updating its metadata without starting it if it's stopped.
    - If the env var `SKIP_BUILD` is set for a remote build, the Cloud Build step is skipped.
    - If `SKIP_DEPLOY` is 1, skips updating the API VM.

**Data notes:**
- `/app/data` is marked as a volume, so they'll persist between container recreations.
- On the VM, the volume is host-bound to `/mnt/stateful_partition/word-lapse-data`, which is located on the 100GB boot disk. We may consider making this an attached disk and shrinking the boot disk if we expect the models to grow.
- `/etc/letsencrypt/` is also marked as a volume, but it isn't bound to the host.
