### PR TITLE
Converts changepoints into list of tuples, updates frontend accordingly

### DIFF
--- a/app/src/api.js
+++ b/app/src/api.js
@@ -44,9 +44,6 @@ export const getResults = async (query) => {
   if ((results?.detail || [])[0]?.msg) throw new Error(results.detail[0].msg);
 
   // transform data as needed
-  results.changepoints = results.changepoints.map(({ changepoint_idx }) =>
-    changepoint_idx.split("-")
-  );
   for (const [key, value] of Object.entries(results.neighbors))
     if (!value.length) delete results.neighbors[key];
 

--- a/server/backend/main.py
+++ b/server/backend/main.py
@@ -146,14 +146,12 @@ async def neighbors(tok: str):
     {
         "neighbors": {<year:str>: [<token:str>, ...]},
         "frequency": [{"year": <year:int>, "frequency": <frequency:float>}, ...],
-        "changepoints": [{"changepoint_idx": <year_range:str>}, ...],
+        "changepoints": [ [<year_start:str>, <year_end:str>], ...],
         "elapsed": <elapsed_ms:float>
     }
     ```
 
     Notes:
-    - `year_range` in `changepoints` is the span of years in which the change
-    took place, e.g. 2019-2020.
     - `elapsed_ms` is the length of time the request took to formulate on
     the server.
     """

--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -51,13 +51,17 @@ def cutoff_points(tok: str):
         data_folder / Path("cusum_changepoint_abstracts.tsv"), sep="\t"
     )
 
-    return (
+    result = (
         cutoff_points
         >> ply.query("tok == @tok")
         >> ply.select("changepoint_idx")
         >> ply.call(".to_dict", orient="records")
     )
 
+    # split hyphens, unnest from object, and return
+    return [
+        [ y.strip() for y in x['changepoint_idx'].split("-") ] for x in result
+    ]
 
 # ========================================================================
 # === extract_neighbors()


### PR DESCRIPTION
This PR converts the changepoints subkey from this older format, e.g.:

```
"changepoints": [
  {
    "changepoint_idx": "2019-2020"
  }
]
```

to this newer format:

```
"changepoints": [
  ["2019", "2020"]
]
```

The code in the frontend that mapped from the old format to the newer one has been removed, too.

Note that since the response has been changed, we'll have to dump and recreate the cache. (This was necessary anyway since the introduction of the 2016 year model, but now it's especially necessary.)

Closes issue #21 .