### PR TITLE
Fixes caching case-sensitivity

### DIFF
--- a/server/backend/main.py
+++ b/server/backend/main.py
@@ -108,9 +108,9 @@ async def enqueue_and_wait(func, *args, **kwargs):
 
 
 def lowercase_tok(func):
-    async def lc_tok(tok):
+    async def neighbors(tok):
         return await func(tok.lower())
-    return lc_tok
+    return neighbors
 
 # ========================================================================
 # === endpoints
@@ -216,7 +216,7 @@ async def neighbors_is_cached(tok: str):
     Note that querying for the token will increase its cache count,
     making it less likely to be evicted.
     """
-    key = redis_cache.get_cache_key(neighbors, tok).replace("lc_tok", "neighbors")
+    key = redis_cache.get_cache_key(neighbors, tok)
     (_, in_cache) = redis_cache.check_cache(key)
     return {"token": tok, "is_cached": True if in_cache is not None else False}
 


### PR DESCRIPTION
The caching library we're using, [fastapi-redis-cache](https://github.com/a-luna/fastapi-redis-cache), uses the verbatim (i.e., case-sensitive) arguments to an endpoint to determine if there's a cached response available or not. This occurs before the endpoint's handler is entered, causing every case variant to be a cache miss even if we lowercase the token in the endpoint handler (as I was naively doing before).

To get around this without having to modify the caching library, I've added a decorator `lowercase_tok()` that runs before the cache decorator, so the decorator ends up seeing the lowercase version of the query token instead and can correctly return a cached version should one exist.