### PR TITLE
Autocomplete Support (API side)

### DIFF
--- a/server/server_requirements.txt
+++ b/server/server_requirements.txt
@@ -4,3 +4,4 @@ uvicorn==0.17.0
 joblib==1.1.0
 fastapi-redis-cache==0.2.5
 rq==1.10.1
+pygtrie==2.4.2


### PR DESCRIPTION
This PR depends on https://github.com/greenelab/word-lapse-models/pull/4 being merged before it's integrated. The PR adds a library, [pygtrie](https://github.com/google/pygtrie), which implements various tries. We're using the `PrefixSet` variant here, since all we need to do is query for elements matching a prefix, not store values in the nodes of the trie.

At initialization, the server looks for a file called `./data/full_vocab.txt` containing a newline-delimited list of words in the corpus. It inserts the contents into a `PrefixSet`, then makes them available via the `/autocomplete` endpoint. The endpoint takes one required parameter `prefix` and one optional parameter `limit` (default 20, capped at 100). The result is a list of strings that occur in the corpus that are prefixed by `prefix`. Note that prefixes shorter than three characters will simply return the prefix itself in a list.

Partially addresses #27 -- there's probably another issue that needs to be created for frontend integration.