### PR TITLE
Ensure frequency years are sorted in the response

### DIFF
--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -42,6 +42,7 @@ def extract_frequencies(tok: str):
         frequency_table
         >> ply.query("tok == @tok")
         >> ply.select("year", "word_count")
+        >> ply.arrange("year")
         >> ply.rename({"frequency": "word_count"})
         >> ply.call(".astype", {"year": int, "frequency": int})
     )


### PR DESCRIPTION
This PR sorts the frequency subkey in `/neighbors` by the year. The fix is currently deployed to the production API server if you'd like to try it out.

Closes #29.