### PR TITLE
Update backend to incorporate the concept mapper

### DIFF
--- a/app/src/api.js
+++ b/app/src/api.js
@@ -47,6 +47,16 @@ export const getResults = async (query) => {
   for (const [key, value] of Object.entries(results.neighbors))
     if (!value.length) delete results.neighbors[key];
 
+  // remap neighbors to just the token field, removing tagged_id
+  // FIXME: if we want to present the tagged_id field in the UI,
+  //  i presume everything that relies on it just being a list of strings
+  //  is going to need to be updated...
+  results.neighbors = (
+    Object.entries(results.neighbors)
+      .map(([year, entries]) => [year, entries.map(({ token }) => token)])
+      .reduce((coll, [year, entries]) => { coll[year] = entries; return coll; }, {})
+  )
+
   // get computed data
   results.uniqueNeighbors = getUnique(results.neighbors);
 

--- a/server/backend/main.py
+++ b/server/backend/main.py
@@ -15,6 +15,7 @@ from rq.job import Job
 from starlette.middleware.cors import CORSMiddleware
 
 from .config import get_config_values
+from .tracking import ExecTimer
 
 logger = logging.getLogger(__name__)
 
@@ -84,17 +85,14 @@ async def init_rq():
 @app.on_event("startup")
 def init_autocomplete_trie():
     global trie
-    with open("./data/full_vocab.txt", "r") as fp:
-        trie = PrefixSet()
-        for line in fp:
-            trie.add(line)
 
-
-@app.on_event("startup")
-def init_concept_map():
-    # prepopulates concept_id_mapper_dict before anything requests it
-    get_concept_id_mapper()
-
+    with ExecTimer(verbose=True):
+        logger.info("Starting trie load...")
+        with open("./data/full_vocab.txt", "r") as fp:
+            trie = PrefixSet()
+            for line in fp:
+                trie.add(line)
+        logger.info("...trie loading done!")
 
 # ========================================================================
 # === helper methods

--- a/server/backend/main.py
+++ b/server/backend/main.py
@@ -14,10 +14,13 @@ from rq.exceptions import NoSuchJobError
 from rq.job import Job
 from starlette.middleware.cors import CORSMiddleware
 
-from .config import get_config_values
+from .config import get_config_values, DEBUG
 from .tracking import ExecTimer
 
+logging.basicConfig()
 logger = logging.getLogger(__name__)
+if DEBUG:
+    logger.setLevel(logging.DEBUG)
 
 app = FastAPI()
 

--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -207,7 +207,7 @@ def query_model_for_tok(
         # Append neighbor to word_neighbor_map
         for neighbor in word_neighbors:
             word_neighbor = neighbor[0]
-            is_tagged = False
+            tag_id = None
 
             # Convert tags that contain the following pattern
             # disease_mesh_####### or chemical_mesh_#######
@@ -218,10 +218,10 @@ def query_model_for_tok(
             # some concpets are tagged and some concepts are missed
             # example: mcf-7 is a cellline but the token itself appears as well
             if word_neighbor in concept_id_mapper_dict:
+                tag_id = word_neighbor
                 word_neighbor = concept_id_mapper_dict[word_neighbor]
-                is_tagged = True
 
-            result.append(dict(token=word_neighbor, is_tagged=is_tagged))
+            result.append(dict(token=word_neighbor, tag_id=tag_id))
 
     return result
 

--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -217,7 +217,7 @@ def query_model_for_tok(
             # Insert tagged suffix to show users that
             # some concpets are tagged and some concepts are missed
             # example: mcf-7 is a cellline but the token itself appears as well
-            if word_neighbor["token"] in concept_id_mapper_dict:
+            if word_neighbor in concept_id_mapper_dict:
                 word_neighbor = concept_id_mapper_dict[word_neighbor]
                 is_tagged = True
 

--- a/server/backend/w2v_worker.py
+++ b/server/backend/w2v_worker.py
@@ -13,6 +13,7 @@ from .neighbors import (
     extract_frequencies,
     extract_neighbors,
     materialized_word_models,
+    get_concept_id_mapper
 )
 from .tracking import ExecTimer
 
@@ -44,12 +45,25 @@ def get_neighbors(tok: str):
             "elapsed": timer.snapshot(),
         }
 
+def load_concept_map():
+    with ExecTimer(verbose=True):
+        # prepopulates concept_id_mapper_dict before anything requests it
+        logger.info("Starting concept mapper load...")
+        get_concept_id_mapper()
+        logger.info("...concept loading done!")
+
 
 def ping(response: str):
     return "pong! %s" % response
 
 
 if __name__ == "__main__":
+    logger.info("Worker started up")
+
+    # load the concept map
+    load_concept_map()
+
+    # load all the year models
     if MATERIALIZE_MODELS and WARM_CACHE:
         # invoke to cache word models into 'word_models'
         logger.info("Warming enabled, preloading word2vec models...")

--- a/server/backend/w2v_worker.py
+++ b/server/backend/w2v_worker.py
@@ -17,8 +17,9 @@ from .neighbors import (
 )
 from .tracking import ExecTimer
 
+logging.basicConfig()
 logger = logging.getLogger(__name__)
-
+logger.setLevel(logging.DEBUG)
 
 def get_neighbors(tok: str):
     with ExecTimer() as timer:


### PR DESCRIPTION
As mentioned on Thursday this code has been adapted to incorporate a concept id mapper to report denormalized concepts back to the user instead of uninformative ids.  I placed the dictionary as a global variable but if there is a better way to do this let me know. 

I also removed the cutoff part of the word2vec models as these new models have been trained to pre-filter words, so performance should go back to expected runtime. 