### PR TITLE
Fix svg download

### DIFF
--- a/app/src/charts/Frequency.css
+++ b/app/src/charts/Frequency.css
@@ -1,8 +1,7 @@
 /* styles we don't want/need in downloaded svg */
 
 .dot:hover {
-  stroke-width: 8;
-  stroke: var(--darkGray);
+  stroke-width: 2px;
   cursor: help;
 }
 

--- a/app/src/components/Combobox.css
+++ b/app/src/components/Combobox.css
@@ -28,7 +28,6 @@
   overflow-x: auto;
   overflow-y: auto;
   background: white;
-  border-radius: 3px;
   box-shadow: 0 1px 3px var(--gray);
 }
 

--- a/app/src/components/Download.js
+++ b/app/src/components/Download.js
@@ -8,11 +8,8 @@ const download = () => {
     downloadSvg(
       svg,
       `word-lapse-${svg.id}`,
-      [
-        ["xmlns", "http://www.w3.org/2000/svg"],
-        ["style", "font-family: sans-serif;"],
-      ],
-      ["data-tooltip"]
+      { style: "font-family: sans-serif;" },
+      [/^data-.*/, /^aria-.*/]
     );
 };
 

--- a/app/src/util/dom.js
+++ b/app/src/util/dom.js
@@ -10,16 +10,33 @@ export const setCssVariables = (variables) => {
 export const downloadSvg = (
   element,
   filename = "chart",
-  addAttrs = [],
-  deleteAttrs = []
+  addAttrs = {},
+  removeAttrs = []
 ) => {
   if (!element) return;
+
+  // make clone of node to work with
   const clone = element.cloneNode(true);
-  for (const [key, value] of addAttrs) clone.setAttribute(key, value);
-  for (const deleteAttr of deleteAttrs)
-    clone
-      .querySelectorAll(`[${deleteAttr}]`)
-      .forEach((el) => el.removeAttribute(deleteAttr));
+
+  // always ensure xmlns so svg is valid outside of html
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+
+  // set other custom attributes on top level svg element
+  for (const [key, value] of Object.entries(addAttrs))
+    clone.setAttribute(key, value);
+
+  // remove specific attributes from all elements
+  for (const element of clone.querySelectorAll("*"))
+    for (const removeAttr of removeAttrs)
+      for (const { name, value } of element.attributes) {
+        console.log(removeAttr, name, value)
+        if (name.match(removeAttr)) {
+          element.removeAttribute(name);
+          continue;
+        }
+      }
+
+  // download clone as svg file
   const data = clone.outerHTML;
   const blob = new Blob([data], { type: "image/svg+xml" });
   const url = window.URL.createObjectURL(blob);

--- a/app/src/util/dom.js
+++ b/app/src/util/dom.js
@@ -15,7 +15,7 @@ export const downloadSvg = (
 ) => {
   if (!element) return;
 
-  // make clone of node to work with
+  // make clone of node to work with and mutate
   const clone = element.cloneNode(true);
 
   // always ensure xmlns so svg is valid outside of html
@@ -28,13 +28,11 @@ export const downloadSvg = (
   // remove specific attributes from all elements
   for (const element of clone.querySelectorAll("*"))
     for (const removeAttr of removeAttrs)
-      for (const { name, value } of element.attributes) {
-        console.log(removeAttr, name, value)
+      for (const { name } of element.attributes)
         if (name.match(removeAttr)) {
           element.removeAttribute(name);
           continue;
         }
-      }
 
   // download clone as svg file
   const data = clone.outerHTML;


### PR DESCRIPTION
- more robustly removes unwanted attributes from svg before downloading. fixes current bug where downloading graphs still includes tooltip attributes which contain unescaped html (which is invalid for a raw svg)
- css tweaks