### PR TITLE
Hot fix for subtle mesh id error

### DIFF
--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -303,6 +303,15 @@ def query_model_for_tok(
     # Check to see if token is in the vocab
     vocab = set(word_vectors.key_to_index.keys())
 
+    if "mesh" in tok:
+        tok = (
+            f"disease_{tok}"
+            if f"disease_{tok}" in vocab
+            else f"chemical_{tok}"
+            if f"chemical_{tok}" in vocab
+            else tok
+        )
+
     if tok in vocab:
         # If it is grab the neighbors
         # Gensim needs to be > 4.0 as they enabled neighbor clipping (remove words from entire vocab)

--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -303,7 +303,17 @@ def query_model_for_tok(
     # Check to see if token is in the vocab
     vocab = set(word_vectors.key_to_index.keys())
 
-    if "mesh" in tok:
+    if tok.startswith("mesh_"):
+        original_tok = tok
+        tok = (
+            f"disease_{tok}" if f"disease_{tok}" in vocab
+            else f"chemical_{tok}" if f"chemical_{tok}" in vocab
+            else tok
+        )
+
+        if tok != original_tok:
+            logger.info(f"remapped token {original_tok} to {tok}")
+
         tok = (
             f"disease_{tok}"
             if f"disease_{tok}" in vocab


### PR DESCRIPTION
This follows up on #42 where the backend enable the search by tag name feature. Every non mesh id works, while every mesh id doesn't. Reason for this problem is that mesh ids cover two distinct entity types: chemicals and diseases. To disambiguate the entity type I appended the type to the corresponding ID and this fix attempts to remedy this issue by testing to see which type the mesh id belongs to/see if it is present in the vocab.

Example of the problem: front end sends:`mesh_d010051` to backend. Backed checks that specific token; however, it be using this token `disease_mesh_d010051` to check the word models.