### PR TITLE
Adds similarity score to umap_coords, neighbors

### DIFF
--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -330,7 +330,7 @@ def query_model_for_tok(
     if tok in vocab:
 
         # Get initial word vector for query token
-        result.append(dict(token=tok, vector=word_vectors[tok], is_query=True))
+        result.append(dict(token=tok, vector=word_vectors[tok], is_query=True, score=1))
 
         # If it is grab the neighbors
         # Gensim needs to be > 4.0 as they enabled neighbor clipping (remove words from entire vocab)
@@ -338,7 +338,7 @@ def query_model_for_tok(
 
         # Append neighbor to word_neighbor_map
         for neighbor in word_neighbors:
-            word_neighbor = neighbor[0]
+            word_neighbor, similarity_score = neighbor
             tag_id = None
             word_vector = word_vectors[word_neighbor]
             entity_features = []
@@ -366,6 +366,7 @@ def query_model_for_tok(
                     tag_id=tag_id,
                     vector=word_vector,
                     is_query=False,
+                    score=similarity_score
                 )
             )
 

--- a/server/backend/w2v_worker.py
+++ b/server/backend/w2v_worker.py
@@ -77,12 +77,16 @@ def split_and_generate_umap_embeddings(word_neighbor_map: dict, neighbors: int =
 
         for idx, tok_entry in enumerate(word_neighbor_map[year]):
             embeddings_matrix.append(tok_entry["vector"])
-            tok_label_list.append((year, tok_entry["token"], tok_entry["is_query"]))
+            tok_label_list.append((year, tok_entry["token"], tok_entry["is_query"], tok_entry["score"]))
 
             # Include the neighbors for the object return
             if idx > 0:
                 word_neighbor_map_returned[year].append(
-                    dict(token=tok_entry["token"], tag_id=tok_entry["tag_id"])
+                    dict(
+                        token=tok_entry["token"],
+                        tag_id=tok_entry["tag_id"],
+                        score=tok_entry["score"],
+                    )
                 )
 
     umap_model = umap.UMAP(
@@ -102,6 +106,7 @@ def split_and_generate_umap_embeddings(word_neighbor_map: dict, neighbors: int =
             year=int(tok_label[0]),
             token=tok_label[1],
             is_query=tok_label[2],
+            score=tok_label[3],
             umap_x_coord=float(umap_coord[0]),
             umap_y_coord=float(umap_coord[1]),
         )


### PR DESCRIPTION
This PR adds a `score` field to each `umap_coords` result (and, indirectly, to each `neighbors` result). The score is retrieved from Gensim's word2vec similarity score returned from [KeyedVectors.most_similar()](https://radimrehurek.com/gensim/models/keyedvectors.html#gensim.models.keyedvectors.KeyedVectors.most_similar) method. Note that the similarity score for the query word is manually set to 1, as it's completely similar with itself (thanks, @danich1, for the explanation).