### PR TITLE
Removes UMAP results from neighbors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ plydata == 0.4.3
 scikit-learn == 0.23.2
 spacy == 2.2.3
 tensorflow >= 2.0.0
-umap-learn == 0.5.1

--- a/server/backend/main.py
+++ b/server/backend/main.py
@@ -236,7 +236,6 @@ async def neighbors(request: Request, tok: str, corpus: str = "pubtator"):
     ```
     {
         "neighbors": {<year:str>: [{"token": <token:str>, "tag_id": <tag_id:str?>, "score": <score:float>}, ...]},
-        "umap_coords": [{"year":<year:int>, "token":<token:str>, "is_query":<is_query:bool>, "score":<score:float>, "umap_x_coord":<umap_x_coord:float>, "umap_y_coord":<umap_y_coord:float>}, ...],
         "frequency": [{"year": <year:int>, "frequency": <frequency:float>}, ...],
         "changepoints": [ [<year_start:str>, <year_end:str>], ...],
         "elapsed": <elapsed_ms:float>
@@ -247,9 +246,9 @@ async def neighbors(request: Request, tok: str, corpus: str = "pubtator"):
     - `elapsed_ms` is the length of time the request took to formulate on
     the server.
     - while the documentation for our word-neighbor querying library doesn't
-    explicitly state that the words are returned in order of decreasing similarity
-    to the target, they appear to be. as a result, `neighbors` and `umap_coords`
-    will typically be in order of decreasing score within a year.
+    explicitly state that the words are returned in order of decreasing
+    similarity to the target, they appear to be. as a result, `neighbors` will
+    typically be in order of decreasing score within a year.
     """
     from .w2v_worker import get_neighbors
 

--- a/server/server_requirements.txt
+++ b/server/server_requirements.txt
@@ -5,4 +5,3 @@ joblib==1.1.0
 fastapi-redis-cache==0.2.5
 rq==1.10.1
 pygtrie==2.4.2
-umap-learn==0.5.3


### PR DESCRIPTION
As of PR #49, we'll no longer be using the UMAP embeddings for the frontend. This PR removes the `umap_coords` key from the `/neighbors` endpoint response, as well as the code that computes the embedding in the backend. The PR also removes the `umap-learn` dependency from the project and cleans up some other unused imports.

Closes #53.