### PR TITLE
Update frequency response based on user feedback

### DIFF
--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -83,11 +83,15 @@ def extract_frequencies(tok: str, corpus: str):
 
     frequency_output_df = (
         frequency_table
+        >> ply.group_by("year")
+        >> ply.define(total="sum(word_count)")
+        >> ply.ungroup()
         >> ply.query("tok == @tok")
-        >> ply.select("year", "word_count")
+        >> ply.define(normalized="word_count/total") 
+        >> ply.select("year", "word_count", "normalized")
         >> ply.arrange("year")
-        >> ply.rename({"frequency": "word_count"})
-        >> ply.call(".astype", {"year": int, "frequency": int})
+        >> ply.rename({"frequency": "word_count", "normalized_frequency": "normalied"})
+        >> ply.call(".astype", {"year": int, "frequency": int, "normalized_frequency": float})
     )
 
     return frequency_output_df >> ply.call(".to_dict", orient="records")

--- a/server/backend/neighbors.py
+++ b/server/backend/neighbors.py
@@ -90,7 +90,7 @@ def extract_frequencies(tok: str, corpus: str):
         >> ply.define(normalized="word_count/total") 
         >> ply.select("year", "word_count", "normalized")
         >> ply.arrange("year")
-        >> ply.rename({"frequency": "word_count", "normalized_frequency": "normalied"})
+        >> ply.rename({"frequency": "word_count", "normalized_frequency": "normalized"})
         >> ply.call(".astype", {"year": int, "frequency": int, "normalized_frequency": float})
     )
 

--- a/server/hotfixes/add_normed_freqs.py
+++ b/server/hotfixes/add_normed_freqs.py
@@ -108,8 +108,8 @@ def main():
             # if the key already has 'normalized_frequency' in it, it's been updated
             if (
                 (
-                    len(decoded['frequencies']) > 0
-                    and 'normalized_frequency' in decoded['frequencies'][0]
+                    len(decoded['frequency']) > 0
+                    and 'normalized_frequency' in decoded['frequency'][0]
                 )
                 and not FORCE_REWRITE_FREQS
             ):
@@ -117,7 +117,7 @@ def main():
                 already_updated += 1
                 continue
 
-            decoded['frequencies'] = extract_frequencies(tok=tok, corpus=corpus)
+            decoded['frequency'] = extract_frequencies(tok=tok, corpus=corpus)
             corrections += 1
 
             if not DRY_RUN:

--- a/server/hotfixes/add_normed_freqs.py
+++ b/server/hotfixes/add_normed_freqs.py
@@ -1,0 +1,132 @@
+#!/usr/local/bin/python
+
+import sys
+import json
+import logging
+import re
+from pathlib import Path
+
+import pandas as pd
+import plydata as ply
+import redis
+from tqdm import tqdm
+
+# patch the server code path into the pythonpath
+sys.path.append(str(Path('..').resolve()))
+
+from backend.config import CORPORA_SET
+from backend.tracking import ExecTimer
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+data_folder = Path("../data")
+
+# if true, skips writing back to the cache
+DRY_RUN = False
+# if true, forces rewriting frequencies even if the entry appears to be up-to-date
+FORCE_REWRITE_FREQS = False
+
+corpus_paths = {
+    "pubtator": data_folder / Path("all_pubtator_tok_frequency.tsv.xz"),
+    "preprints": data_folder / Path("all_preprint_tok_frequency.tsv.xz"),
+}
+
+with ExecTimer(verbose=True):
+    print("Loading corpora...")
+    frequency_tables_ungropued = {
+        corpus: (
+            pd.read_csv(corpus_paths[corpus], sep="\t")
+            >> ply.group_by("year")
+            >> ply.define(total="sum(word_count)")
+            >> ply.ungroup()
+        )
+        for corpus in corpus_paths
+    }
+    print("done!")
+
+def extract_frequencies(tok: str, corpus: str):
+    frequency_output_df = (
+        frequency_tables_ungropued[corpus]
+        >> ply.query("tok == @tok")
+        >> ply.define(normalized="word_count/total") 
+        >> ply.select("year", "word_count", "normalized")
+        >> ply.arrange("year")
+        >> ply.rename({"frequency": "word_count", "normalized_frequency": "normalized"})
+        >> ply.call(".astype", {"year": int, "frequency": int, "normalized_frequency": float})
+    )
+
+    return frequency_output_df >> ply.call(".to_dict", orient="records")
+
+
+def main():
+    r = redis.Redis( host='localhost', port=6379)
+
+    corrections = 0
+    skips = 0
+    already_updated = 0
+    renames = 0
+
+    if DRY_RUN:
+        logger.info("DRY_RUN enabled, cache won't be modified")
+
+    # get number of records so we can build a progress bar
+    logger.info("Computing total records...")
+    total_recs = sum(1 for _ in r.scan_iter('wlc:*'))
+    logger.info("done! %d entries found" % total_recs)
+
+    corpora_labels_to_ids = {
+        v: k for k, v in CORPORA_SET.items()
+    }
+
+    with ExecTimer(verbose=True):
+        for cached_key in tqdm(r.scan_iter('wlc:*'), total=total_recs):
+            decoded = json.loads(r.get(cached_key))
+
+            try:
+                tok, corpus = re.match(
+                    r".*\(tok=(.+),corpus=(.+)\)",
+                    str(cached_key)
+                ).groups()
+            except AttributeError:
+                tqdm.write("Skipped key '%s' due to regex not matching" % cached_key)
+                skips += 1
+                continue
+
+            # check if the corpus label rather than the corpus id was specified
+            # if so, rename the key and continue
+            if corpus in corpora_labels_to_ids:
+                old_key = cached_key
+                cached_key = str(cached_key).replace(corpus, corpora_labels_to_ids[corpus])
+                corpus = corpora_labels_to_ids[corpus]
+                r.rename(old_key, cached_key)
+                renames += 1
+                tqdm.write("Corrected corpus label; %s => %s" % (old_key, cached_key))
+
+            tqdm.write("Token: %s, corpus: %s" % (tok, corpus))
+
+            # if the key already has 'normalized_frequency' in it, it's been updated
+            if (
+                (
+                    len(decoded['frequencies']) > 0
+                    and 'normalized_frequency' in decoded['frequencies'][0]
+                )
+                and not FORCE_REWRITE_FREQS
+            ):
+                tqdm.write("Key '%s' is already updated, continuing..." % cached_key)
+                already_updated += 1
+                continue
+
+            decoded['frequencies'] = extract_frequencies(tok=tok, corpus=corpus)
+            corrections += 1
+
+            if not DRY_RUN:
+                r.set(cached_key, json.dumps(decoded))
+
+    print("Corrections: %d" % corrections)
+    print("Skipped due to missing key: %d" % skips)
+    print("Renamed: %d" % renames)
+    print("Already updated: %d" % already_updated)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR is in response to #60. The quick change here is that I added a field for frequency to have a normalized form based on all tokens found within a given year. Backend response now has a field called normalized frequency. 

Main frontend changes will need to be as follows below (I think it should be a very quick fix🤞🏾) @vincerubinetti:
  - the frequency visualization will need a feature to allow users to toggle between normalized frequency and regular frequency
  - the frequency visualization will need a feature that allows users to change from linear to log scale when displaying the regular frequency. (normalized version will only need to be reported in scientific notation e.g. 2.5e-3)