### PR TITLE
Incorporate normalized frequency into frontend

### DIFF
--- a/app/src/api.js
+++ b/app/src/api.js
@@ -67,10 +67,19 @@ export const getResults = async (query, corpus) => {
   // api error
   if (results?.detail?.[0]?.msg) throw new Error(results.detail[0].msg);
 
+  // transform frequency data
+  results.frequency = results.frequency.map(
+    ({ frequency, normalized_frequency, year }) => ({
+      frequency,
+      normalized: normalized_frequency,
+      year,
+    })
+  );
+
   // delete empty years
   results.neighbors = omitBy(results.neighbors, isEmpty);
 
-  // transform/compute data
+  // transform/compute neighbors data
   results.neighbors = mapValues(results.neighbors, (neighbors) =>
     map(neighbors, ({ token, tag_id, score }) => ({
       // plain text word

--- a/app/src/assets/scale-linear.svg
+++ b/app/src/assets/scale-linear.svg
@@ -1,0 +1,16 @@
+<svg viewBox="-10 -110 120 120">
+  <path
+    fill="none"
+    stroke="currentColor"
+    stroke-width="15"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="
+      M 0 -100
+      L 0 0
+      L 100 0
+      M 30 -30
+      L 90 -90
+    "
+  />
+</svg>

--- a/app/src/assets/scale-log.svg
+++ b/app/src/assets/scale-log.svg
@@ -1,0 +1,16 @@
+<svg viewBox="-10 -110 120 120">
+  <path
+    fill="none"
+    stroke="currentColor"
+    stroke-width="15"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="
+      M 0 -100
+      L 0 0
+      L 100 0
+      M 30 -30
+      A 70 70 0 0 1 100 -80
+    "
+  />
+</svg>

--- a/app/src/charts/Frequency.js
+++ b/app/src/charts/Frequency.js
@@ -21,13 +21,13 @@ import Button from "../components/Button";
 import "./Frequency.css";
 import { ReactComponent as ScaleLinear } from "../assets/scale-linear.svg";
 import { ReactComponent as ScaleLog } from "../assets/scale-log.svg";
-import { compactNumber } from "../util/string";
+import { compactNumber, logLabel } from "../util/string";
 
 // unique id of this chart
 const id = "frequency";
 
 // dimensions of main chart area, in SVG units. use to set aspect ratio.
-const width = 400;
+const width = 380;
 const height = 200;
 
 // duration of animations (in ms)
@@ -177,8 +177,10 @@ const chart = (frequency, changepoints, normalized, linear, frequencyIndex) => {
   const xAxis = axisBottom(xScale)
     .ticks(frequency.length / 2)
     .tickFormat((d) => d);
-  const yAxis = axisLeft(yScale);
-  yAxis.tickFormat(compactNumber);
+  const yAxis = axisLeft(yScale).tickFormat(
+    linear ? compactNumber : logLabel([1, 2, 5], compactNumber)
+  );
+
   svg
     .select(".x-axis")
     .interrupt()
@@ -248,12 +250,12 @@ const Frequency = () => {
           Year
         </text>
         <text
-          transform={`translate(-40, -${height / 2}) rotate(-90)`}
+          transform={`translate(-50, -${height / 2}) rotate(-90)`}
           textAnchor="middle"
           dominantBaseline="middle"
           style={{ fontSize: "12px" }}
         >
-          Frequency
+          {normalized ? "Normalized" : "Absolute"} Frequency
         </text>
         <text
           x={width / 2}

--- a/app/src/charts/Trajectory.css
+++ b/app/src/charts/Trajectory.css
@@ -13,9 +13,3 @@
     opacity: 100%;
   }
 }
-
-#trajectory .word {
-  stroke: white;
-  stroke-width: 2;
-  paint-order: stroke;
-}

--- a/app/src/components/Button.css
+++ b/app/src/components/Button.css
@@ -25,3 +25,7 @@
   height: 30px;
   flex-shrink: 0;
 }
+
+.custom-icon {
+  height: 1em;
+}

--- a/app/src/components/Button.js
+++ b/app/src/components/Button.js
@@ -2,8 +2,9 @@ import { forwardRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "./Button.css";
 
-const Button = forwardRef(({ text, icon, ...props }, ref) => (
+const Button = forwardRef(({ text, icon, CustomIcon = () => <></>, ...props }, ref) => (
   <button ref={ref} {...props} data-square={icon && !text} className="button">
+    <CustomIcon className="custom-icon" />
     {icon && <FontAwesomeIcon icon={icon} />}
     {text && <span>{text}</span>}
   </button>

--- a/app/src/components/Title.css
+++ b/app/src/components/Title.css
@@ -24,25 +24,6 @@
   dominant-baseline: middle;
 }
 
-header[data-fullscreen="true"] .title text {
-  animation: shine 3s ease-in-out infinite;
-}
-
-@keyframes shine {
-  0% {
-    stroke: black;
-  }
-  20% {
-    stroke: var(--color);
-  }
-  40% {
-    stroke: black;
-  }
-  100% {
-    stroke: black;
-  }
-}
-
 header[data-fullscreen="false"] .title {
   flex-direction: row;
   gap: 0;

--- a/app/src/components/Title.js
+++ b/app/src/components/Title.js
@@ -52,7 +52,6 @@ const Title = () => (
               x={x}
               y="1"
               filter={`url(#drop-shadow-${id})`}
-              style={{ animationDelay: id * 0.2 + "s" }}
             >
               {char}
             </text>

--- a/app/src/palette.js
+++ b/app/src/palette.js
@@ -53,10 +53,12 @@ library.add(
   fas.faDownload,
   fas.faExclamationCircle,
   fas.faFont,
+  fas.faHashtag,
   fas.faIcons,
   fas.faInfoCircle,
   fas.faLeftRight,
   fas.faPause,
+  fas.faPercent,
   fas.faPlay,
   fas.faRightLong,
   fas.faSpinner

--- a/app/src/util/string.js
+++ b/app/src/util/string.js
@@ -57,3 +57,9 @@ export const join = (array = [], separator = " ") =>
 const formatter = Intl.NumberFormat("en", { notation: "compact" });
 export const compactNumber = (value) =>
   value < 1 ? value.toExponential(1) : formatter.format(value).toLowerCase();
+
+// get axis tick labels for log scale
+export const logLabel = (powers, format) => (d) =>
+  // only return label if number is a "multiple" of one of powers
+  // otherwise skip tick (give it a blank label)
+  powers.some((power) => Math.log10(d / power) % 1 === 0) ? format(d) : "";

--- a/app/src/util/string.js
+++ b/app/src/util/string.js
@@ -52,3 +52,8 @@ export const getWidth = (text, size) => {
 // filter array and join
 export const join = (array = [], separator = " ") =>
   array.filter((part) => part.trim()).join(separator);
+
+// convert number to compact form (e.g. with "k" for 1000)
+const formatter = Intl.NumberFormat("en", { notation: "compact" });
+export const compactNumber = (value) =>
+  value < 1 ? value.toExponential(1) : formatter.format(value).toLowerCase();


### PR DESCRIPTION
- get normalized frequency from backend
- make custom svg icons for scales
- incorp normalized frequency into frequency chart. refactor chart code, remove some transitions, rework axes, add button controls to toggle between normalized and scales. for log scale, manually skip labels to create uniform label spacing, because d3's nice spacing algo can't be used when you also provide a custom format function for the label text.
- refactor and simplify trajectory chart. just put one neighbor per line to reduce complexity and make each year look more consistent instead of like [this mess](https://twitter.com/GreeneScientist/status/1527737938578112512). also truncate first neighbor next to a curve more than subsequent lines to reduce chance of text overlapping the curve.
- let button component take custom icon
- remove logo animation (too subtle, doesn't really look good, we have enough animation behind it anyway)
- consistent number util func